### PR TITLE
Use frame_offset instead of frame for Cue Point position

### DIFF
--- a/src/cue.rs
+++ b/src/cue.rs
@@ -364,7 +364,7 @@ impl Cue {
             .map(|i| {
                 Cue {
                     //ident : i.cue_point_id,
-                    frame : i.frame,
+                    frame : i.frame_offset,
                     length: {
                         raw_adtl.ltxt_for_cue_point(i.cue_point_id).first()
                         .filter(|x| x.purpose == FourCC::make(b"rgn "))

--- a/src/cue.rs
+++ b/src/cue.rs
@@ -281,7 +281,16 @@ pub struct Cue {
     pub label : Option<String>,
 
     /// The text "note"/comment of this marker if provided
-    pub note : Option<String>
+    pub note : Option<String>,
+    
+    /// The offser of this marker
+    /// 
+    /// **Note:** Applications use the `frame` and `offset` fields
+    /// in different ways. iZotope RX Audio Editor writes the
+    /// marker position to *both* fields, while a Sound Devices
+    /// recorder writes the marker position to *only* the `offset`
+    /// field.
+    pub offset : u32
 }
 
 
@@ -306,7 +315,7 @@ impl Cue {
                     chunk_id: DATA_SIG,
                     chunk_start: 0,
                     block_start: 0,
-                    frame_offset: cue.frame
+                    frame_offset: cue.offset
                 };
 
                 let raw_label = cue.label.as_ref().map(|val| {
@@ -364,7 +373,7 @@ impl Cue {
             .map(|i| {
                 Cue {
                     //ident : i.cue_point_id,
-                    frame : i.frame_offset,
+                    frame : i.frame,
                     length: {
                         raw_adtl.ltxt_for_cue_point(i.cue_point_id).first()
                         .filter(|x| x.purpose == FourCC::make(b"rgn "))
@@ -380,7 +389,8 @@ impl Cue {
                             //.filter_map(|x| str::from_utf8(&x.text).ok())
                             .map(|s| convert_to_cue_string(&s.text))
                             .next()
-                    }
+                    },
+                    offset: i.frame_offset
                 }
             }).collect() 
         )

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -158,7 +158,7 @@ fn test_channels_stereo_no_fmt_extended() {
     assert_eq!(channels[1].speaker,ChannelMask::FrontRight);
 }
 
-//See issue 6 and 7
+///See issue 6 and 7
 #[test]
 fn test_frame_reader_consumes_reader() {
     // Issue #6
@@ -175,4 +175,48 @@ fn test_frame_reader_consumes_reader() {
     }
 
     let _result = from_wav_filename("tests/media/pt_24bit_stereo.wav").unwrap();
+}
+
+///See to PR#10
+#[test]
+fn test_cue_read_sounddevices() {
+    let mut f = WaveReader::open("tests/media/sounddevices_6_cue_points.wav").unwrap();
+    let cue_points = f.cue_points().unwrap();
+    assert_eq!(cue_points.len(), 6);
+
+    assert_eq!(cue_points[0].frame, 0);
+    assert_eq!(cue_points[0].length, None);
+    assert_eq!(cue_points[0].label, None);
+    assert_eq!(cue_points[0].note, None);
+    assert_eq!(cue_points[0].offset, 90112);
+    
+    assert_eq!(cue_points[1].frame, 0);
+    assert_eq!(cue_points[1].length, None);
+    assert_eq!(cue_points[1].label, None);
+    assert_eq!(cue_points[1].note, None); 
+    assert_eq!(cue_points[1].offset, 176128);
+     
+    assert_eq!(cue_points[2].frame, 0);
+    assert_eq!(cue_points[2].length, None);
+    assert_eq!(cue_points[2].label, None);
+    assert_eq!(cue_points[2].note, None); 
+    assert_eq!(cue_points[2].offset, 237568);
+
+    assert_eq!(cue_points[3].frame, 0);
+    assert_eq!(cue_points[3].length, None);
+    assert_eq!(cue_points[3].label, None);
+    assert_eq!(cue_points[3].note, None); 
+    assert_eq!(cue_points[3].offset, 294912);
+
+    assert_eq!(cue_points[4].frame, 0);
+    assert_eq!(cue_points[4].length, None);
+    assert_eq!(cue_points[4].label, None);
+    assert_eq!(cue_points[4].note, None); 
+    assert_eq!(cue_points[4].offset, 380928);
+
+    assert_eq!(cue_points[5].frame, 0);
+    assert_eq!(cue_points[5].length, None);
+    assert_eq!(cue_points[5].label, None);
+    assert_eq!(cue_points[5].note, None); 
+    assert_eq!(cue_points[5].offset, 385024);
 }


### PR DESCRIPTION
As described in issue #9 cuepoints from a Sound Devices MixPre-Series recorder are returned with the wrong frame value of always 0. I tried the suggested fix in a fork and it worked for me as expected with both files. I tried running the tests, but as I am currently on a windows machine I guess I am out of luck with that one.

Feel free to modify, deny, etc this PR if there are things which I overlooked.