### PR TITLE
implement basic f32le support and some other misc fixes

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
-use std::io;
+use std::{fmt::{Debug,Display}, io};
+use std::error::Error as StdError;
 use super::fourcc::FourCC;
 
 use uuid;
@@ -41,6 +42,14 @@ pub enum Error {
     /// The file is not optimized for writing new data
     DataChunkNotPreparedForAppend,
 
+}
+
+impl StdError for Error {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(self, f)
+    }
 }
 
 

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -18,6 +18,7 @@ use byteorder::{WriteBytesExt, ReadBytesExt};
 /// `AudioProgramme`.
 /// 
 /// See BS.2088-1 § 8, also BS.2094, also blahblahblah...
+#[derive(Debug)]
 pub struct ADMAudioID {
     pub track_uid: [char; 12],
     pub channel_format_ref: [char; 14],
@@ -28,6 +29,7 @@ pub struct ADMAudioID {
 /// 
 /// This information is correlated from the Wave format ChannelMap field and
 /// the `chna` chunk, if present.
+#[derive(Debug)]
 pub struct ChannelDescriptor {
     /// Index, the offset of this channel's samples in one frame.
     pub index: u16,


### PR DESCRIPTION
current error doesn't implement std::error::Error which can be a bit annoying when e.g. working with anyhow,

this also implements the basic (and iirc only) float pcm wav format