### PR TITLE
Parser: handle missing trailing pad on final odd-length chunk

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -256,9 +256,19 @@ impl<R: Read + Seek> Parser<R> {
                 content_length: this_size,
             };
 
+            // Saturating sub: real-world WAVE/BWF encoders sometimes
+            // omit the strict-RIFF pad byte on the final odd-length
+            // chunk of a file. Without saturation, `remaining - 8 -
+            // this_displacement` underflows the u64 for that last
+            // chunk and wraps to ~u64::MAX, causing the next iteration
+            // to attempt reading past EOF and emit
+            // `IOError(UnexpectedEof)`. Saturating to 0 makes the next
+            // iteration emit `FinishParse` cleanly. The chunk's
+            // `BeginChunk` event still reports the correct (pre-pad)
+            // `content_length`, so callers see the right extent.
             state = State::ReadyForChunk {
                 at: at + 8 + this_displacement,
-                remaining: remaining - 8 - this_displacement,
+                remaining: remaining.saturating_sub(8 + this_displacement),
             }
         }
 
@@ -290,5 +300,45 @@ impl<R: Read + Seek> Parser<R> {
             Ok((event, state)) => (event, state),
             Err(error) => (Some(Event::Failed { error }), State::Error),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// Real-world broadcast files (e.g. MP2-WAV from public-radio
+    /// distribution systems) sometimes omit the strict-RIFF pad byte
+    /// on the final odd-length chunk, ending exactly at EOF. The
+    /// parser must accept this without underflowing `remaining`.
+    #[test]
+    fn parser_handles_missing_trailing_pad_on_final_odd_chunk() {
+        // Construct a minimal WAVE:
+        //   RIFF + size + WAVE + fmt(16, even) + data(3, odd) — no pad
+        //   = 4 + 4 + 4 + 8 + 16 + 8 + 3 = 47 bytes
+        // RIFF size field = 47 - 8 = 39
+        let mut buf = Vec::new();
+        buf.extend_from_slice(b"RIFF");
+        buf.extend_from_slice(&39u32.to_le_bytes());
+        buf.extend_from_slice(b"WAVE");
+        buf.extend_from_slice(b"fmt ");
+        buf.extend_from_slice(&16u32.to_le_bytes());
+        buf.extend_from_slice(&[0u8; 16]);
+        buf.extend_from_slice(b"data");
+        buf.extend_from_slice(&3u32.to_le_bytes());
+        buf.extend_from_slice(&[0xAA, 0xBB, 0xCC]);
+        assert_eq!(buf.len(), 47);
+
+        let chunks = Parser::make(Cursor::new(&buf))
+            .unwrap()
+            .into_chunk_list()
+            .expect("parser should accept a missing trailing pad on the final odd-length chunk");
+
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].signature, FourCC::from(*b"fmt "));
+        assert_eq!(chunks[0].length, 16);
+        assert_eq!(chunks[1].signature, DATA_SIG);
+        assert_eq!(chunks[1].length, 3);
     }
 }


### PR DESCRIPTION
## Summary

Fixes a parser failure on real-world WAVE/BWF files that omit the strict-RIFF pad byte at end-of-file when the final chunk is odd-length and ends exactly at EOF. This pattern is common with broadcast MP2-WAV files where the `data` chunk is last.

## The bug

In `Parser::enter_chunk`, when a chunk is consumed:

```rust
state = State::ReadyForChunk {
    at: at + 8 + this_displacement,
    remaining: remaining - 8 - this_displacement,
}
```

`this_displacement` adds 1 for odd-length chunks to account for the RIFF pad byte. When the file lacks that pad on the final chunk, `remaining - 8 - this_displacement` underflows the `u64` for that last chunk and wraps to `~u64::MAX`. The next iteration then attempts to read another chunk header past EOF and the parser emits `IOError(UnexpectedEof)` instead of `FinishParse`.

## The fix

Use `saturating_sub` so `remaining` clamps to 0 on the boundary case. The next iteration sees `remaining == 0` and emits `FinishParse` cleanly. The chunk's `BeginChunk` event still reports the correct (pre-pad) `content_length`, so callers see the right data extent.

## Regression test

Added an in-memory test that constructs a minimal WAV with an odd-length `data` chunk and no trailing pad. Without the fix, `Parser::into_chunk_list` returns `Err(IOError(UnexpectedEof))`. With the fix, it returns `Ok` with both chunks correctly described.

## Real-world impact

Found while running a verification tool against a directory of 31 broadcast MP2-WAV files (mix of public-radio distribution sources). 18 of 31 failed to parse before this fix; all 31 succeed after.

## Test plan
- [x] Existing test suite passes (`cargo test --lib --tests`)
- [x] New unit test `parser_handles_missing_trailing_pad_on_final_odd_chunk` covers the boundary case
- [x] Verified against real broadcast files outside the test corpus