### PR TITLE
fmt writer: use cbSize=22 for WAVEFORMATEXTENSIBLE (per Microsoft spec)

### DIFF
--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -37,7 +37,12 @@ where
         self.write_u16::<LittleEndian>(format.block_alignment)?;
         self.write_u16::<LittleEndian>(format.bits_per_sample)?;
         if let Some(ext) = format.extended_format {
-            let cb_size = 24u16;
+            // Per Microsoft's WAVEFORMATEXTENSIBLE spec, cbSize declares
+            // the size of the extension *after* the cbSize field itself:
+            // wValidBitsPerSample (2) + dwChannelMask (4) + SubFormat (16)
+            // = 22 bytes. Writing 24 misreports the extension size; many
+            // readers tolerate it, but strict ones will over-read.
+            let cb_size = 22u16;
             self.write_u16::<LittleEndian>(cb_size)?;
             self.write_u16::<LittleEndian>(ext.valid_bits_per_sample)?;
             self.write_u32::<LittleEndian>(ext.channel_mask)?;
@@ -215,6 +220,45 @@ where
             },
         })
     }
+}
+
+#[test]
+fn write_wave_fmt_extensible_uses_cbsize_22() {
+    // Regression: cbSize for WAVEFORMATEXTENSIBLE must be 22 (the
+    // size of the extension *after* the cbSize field itself), per
+    // Microsoft spec: wValidBitsPerSample (2) + dwChannelMask (4) +
+    // SubFormat GUID (16) = 22.
+    use super::common_format::WAVE_UUID_PCM;
+    use super::fmt::{WaveFmt, WaveFmtExtended};
+    use std::io::Cursor;
+
+    let format = WaveFmt {
+        tag: 0xFFFE,
+        channel_count: 2,
+        sample_rate: 48000,
+        bytes_per_second: 192_000,
+        block_alignment: 4,
+        bits_per_sample: 16,
+        extended_format: Some(WaveFmtExtended {
+            valid_bits_per_sample: 16,
+            channel_mask: 0x3,
+            type_guid: WAVE_UUID_PCM,
+        }),
+    };
+
+    let mut buf = Cursor::new(Vec::<u8>::new());
+    buf.write_wave_fmt(&format).unwrap();
+    let bytes = buf.into_inner();
+
+    // Base WAVEFORMATEX (16) + cbSize field (2) + extension (22) = 40
+    assert_eq!(bytes.len(), 40);
+
+    // cbSize is at offset 16, little-endian
+    let cb_size = u16::from_le_bytes([bytes[16], bytes[17]]);
+    assert_eq!(
+        cb_size, 22,
+        "cbSize must be 22 per WAVEFORMATEXTENSIBLE spec"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes the `cbSize` field emitted for `WAVEFORMATEXTENSIBLE` from 24 to 22, matching Microsoft's specification.

## The bug

Per Microsoft's [WAVEFORMATEXTENSIBLE](https://learn.microsoft.com/en-us/windows/win32/api/mmreg/ns-mmreg-waveformatextensible) spec, `cbSize` declares the size of the extension *after* the `cbSize` field itself:

    wValidBitsPerSample (2) + dwChannelMask (4) + SubFormat GUID (16) = 22

The writer in `src/chunks.rs` was emitting `cbSize=24`, which misreports the extension size. Most readers tolerate this because they consume the 22 fields directly without using `cbSize` for advancement, but a strict reader following `cbSize` would over-read by 2 bytes into adjacent data.

## Compatibility

bwavfile's own reader uses `assert!(cb_size >= 22, ...)` and reads the 22 fields directly, so the fix is non-breaking for self-round-tripping. Files produced by previous versions (`cbSize=24`) continue to read correctly because the reader accepts `cbSize >= 22`.

Files produced by this version will have `cbSize=22` instead of 24. Semantically equivalent — no field values change — but byte-different for tools that do byte-exact comparison against pre-fix outputs.

## Regression test

Added `write_wave_fmt_extensible_uses_cbsize_22` which constructs a `WaveFmt` with extensible PCM, writes it, and verifies:
- Total written length is 40 bytes (16 base + 2 cbSize + 22 extension)
- The bytes at offset 16-17 (cbSize) parse as 22 little-endian

## Test plan
- [x] New test `write_wave_fmt_extensible_uses_cbsize_22` passes
- [x] Existing test suite passes (`cargo test --lib --tests`)
- [x] Round-trip via existing `read_wave_fmt` works (reader accepts `cb_size >= 22`)