### PR TITLE
Additive public APIs for working with codec-encoded data chunks

### DIFF
--- a/src/bext.rs
+++ b/src/bext.rs
@@ -19,7 +19,7 @@ pub type Decibels = f32;
 /// - [EBU Tech R099](https://tech.ebu.ch/docs/r/r099.pdf) (October 2011) "‘Unique’ Source Identifier (USID) for use in the
 ///   &lt;OriginatorReference&gt; field of the Broadcast Wave Format"
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Bext {
     /// 0..256 ASCII character field with free text.
     pub description: String,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,6 +47,12 @@ pub enum Error {
         buffer_size: usize,
         channel_count: u16,
     },
+
+    /// The wave file's audio format is not supported by `AudioFrameReader`
+    /// (e.g. MPEG, ADPCM, A-Law). Use codec-specific tools to decode the
+    /// `data` chunk; this crate exposes the raw bytes via
+    /// [`crate::WaveReader::read_data_chunk`].
+    UnsupportedAudioFormat { tag: u16 },
 }
 
 impl StdError for Error {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ mod errors;
 mod fourcc;
 
 mod list_form;
-mod parser;
+pub mod parser;
 
 mod bext;
 mod chunks;
@@ -53,6 +53,8 @@ pub use errors::Error;
 pub use fmt::{
     ADMAudioID, ChannelDescriptor, ChannelMask, ReadWavAudioData, WaveFmt, WaveFmtExtended,
 };
+pub use fourcc::FourCC;
+pub use parser::{ChunkIteratorItem, Parser};
 pub use sample::{Sample, I24};
 pub use wavereader::{AudioFrameReader, WaveReader};
 pub use wavewriter::{AudioFrameWriter, WaveWriter};

--- a/src/wavereader.rs
+++ b/src/wavereader.rs
@@ -48,18 +48,21 @@ impl<R: Read + Seek> AudioFrameReader<R> {
     /// and the format tag is readable by this implementation (only
     /// format 0x01 is supported at this time.)
     pub fn new(mut inner: R, format: WaveFmt, start: u64, length: u64) -> Result<Self, Error> {
+        // Reject codec-encoded formats (MPEG, ADPCM, A-Law, etc.)
+        // cleanly before doing the PCM block-alignment check below.
+        // Those formats legitimately violate `block_alignment * 8 ==
+        // bits_per_sample * channel_count`. Callers that want raw
+        // bytes should use `WaveReader::read_data_chunk` instead.
+        let common = format.common_format();
+        if common != CommonFormat::IntegerPCM && common != CommonFormat::IeeeFloatPCM {
+            return Err(Error::UnsupportedAudioFormat { tag: format.tag });
+        }
+
         assert!(
             format.block_alignment * 8 == format.bits_per_sample * format.channel_count,
             "Unable to read audio frames from packed formats: block alignment is {}, should be {}",
             format.block_alignment,
             (format.bits_per_sample / 8) * format.channel_count
-        );
-
-        assert!(
-            format.common_format() == CommonFormat::IntegerPCM
-                || format.common_format() == CommonFormat::IeeeFloatPCM,
-            "Unsupported format tag {:?}",
-            format.tag
         );
 
         inner.seek(Start(start))?;
@@ -413,6 +416,20 @@ impl<R: Read + Seek> WaveReader<R> {
         self.read_chunk(AXML_SIG, 0, buffer)
     }
 
+    /// Read the raw bytes of the `data` chunk into `buffer`.
+    ///
+    /// For PCM files these are raw sample bytes (use [`audio_frame_reader`](Self::audio_frame_reader)
+    /// instead for sample-level access). For codec-encoded data
+    /// (MPEG, ADPCM, A-Law, etc.) these are the codec body, which a
+    /// caller can hand to a separate codec implementation for
+    /// decoding.
+    ///
+    /// Returns the number of bytes read, or `Ok(0)` if the file has
+    /// no `data` chunk.
+    pub fn read_data_chunk(&mut self, buffer: &mut Vec<u8>) -> Result<usize, ParserError> {
+        self.read_chunk(DATA_SIG, 0, buffer)
+    }
+
     /**
      * Validate file is readable.
      *
@@ -639,4 +656,32 @@ fn test_list_form() {
     f.read_list(ADTL_SIG, &mut buf).unwrap();
 
     assert_ne!(buf.len(), 0);
+}
+
+#[test]
+fn audio_frame_reader_rejects_unsupported_format_cleanly() {
+    use std::io::Cursor;
+
+    // Construct a WaveFmt with the MPEG-1 tag (0x0050). AudioFrameReader
+    // can only decode IntegerPCM and IeeeFloatPCM, so any other tag
+    // must return Err(UnsupportedAudioFormat) instead of panicking.
+    let mpeg_format = WaveFmt {
+        tag: 0x0050,
+        channel_count: 2,
+        sample_rate: 44100,
+        bytes_per_second: 32000,
+        block_alignment: 836,
+        bits_per_sample: 0xFFFF,
+        extended_format: None,
+    };
+
+    let cursor = Cursor::new(vec![0u8; 16]);
+    let result = AudioFrameReader::new(cursor, mpeg_format, 0, 16);
+    match result {
+        Err(Error::UnsupportedAudioFormat { tag: 0x0050 }) => {}
+        other => panic!(
+            "expected UnsupportedAudioFormat {{ tag: 0x0050 }}, got: {:?}",
+            other
+        ),
+    }
 }

--- a/src/wavewriter.rs
+++ b/src/wavewriter.rs
@@ -307,9 +307,37 @@ where
     /// Wrap a writer in a Wave writer.
     ///
     /// The inner writer will immediately have a RIFF WAVE file header
-    /// written to it along with the format descriptor (and possibly a `fact`
-    /// chunk if appropriate).
-    pub fn new(mut inner: W, format: WaveFmt) -> Result<Self, Error> {
+    /// written to it along with a 96-byte `JUNK` chunk reserving space
+    /// for in-place upgrade to RF64 if data later exceeds 4 GiB,
+    /// followed by the `fmt` chunk.
+    ///
+    /// For files guaranteed to stay under 4 GiB and that don't need
+    /// the RF64 promotion path, see
+    /// [`new_without_ds64_reservation`](Self::new_without_ds64_reservation)
+    /// — it omits the JUNK chunk for a more compact output.
+    pub fn new(inner: W, format: WaveFmt) -> Result<Self, Error> {
+        Self::new_with_options(inner, format, true)
+    }
+
+    /// Wrap a writer in a Wave writer **without** reserving space for
+    /// a future RF64 upgrade.
+    ///
+    /// Equivalent to [`new`](Self::new) except the 96-byte `JUNK`
+    /// `ds64` reservation is omitted. The output is more compact and
+    /// matches the byte layout produced by encoders that don't expect
+    /// to need RF64 (e.g. broadcast distribution files using codec
+    /// data, where the data chunk is well under the 4 GiB threshold).
+    ///
+    /// The resulting writer **cannot** be safely upgraded to RF64
+    /// in-place — if more than 4 GiB of total form length would be
+    /// written, the `RIFF` size field overflows and the writer's
+    /// behavior is unspecified. Use the regular [`new`](Self::new)
+    /// for any file whose final size is unknown.
+    pub fn new_without_ds64_reservation(inner: W, format: WaveFmt) -> Result<Self, Error> {
+        Self::new_with_options(inner, format, false)
+    }
+
+    fn new_with_options(mut inner: W, format: WaveFmt, reserve_ds64: bool) -> Result<Self, Error> {
         inner.write_fourcc(RIFF_SIG)?;
         inner.write_u32::<LittleEndian>(0)?;
         inner.write_fourcc(WAVE_SIG)?;
@@ -323,8 +351,9 @@ where
 
         retval.increment_form_length(4)?;
 
-        // write ds64_reservation
-        retval.write_junk(DS64_RESERVATION_LENGTH)?;
+        if reserve_ds64 {
+            retval.write_junk(DS64_RESERVATION_LENGTH)?;
+        }
 
         let mut chunk = retval.chunk(FMT__SIG)?;
         chunk.write_wave_fmt(&format)?;
@@ -461,6 +490,28 @@ fn test_new() {
     assert_eq!(cursor.read_fourcc().unwrap(), FMT__SIG);
     let fmt_size = cursor.read_u32::<LittleEndian>().unwrap();
     assert_eq!(form_size, 4 + 8 + junk_size + 8 + fmt_size);
+}
+
+#[test]
+fn test_new_without_ds64_reservation() {
+    use super::fourcc::ReadFourCC;
+    use byteorder::ReadBytesExt;
+    use std::io::Cursor;
+
+    let mut cursor = Cursor::new(vec![0u8; 0]);
+    let format = WaveFmt::new_pcm_mono(48000, 24);
+    WaveWriter::new_without_ds64_reservation(&mut cursor, format).unwrap();
+
+    cursor.seek(SeekFrom::Start(0)).unwrap();
+    assert_eq!(cursor.read_fourcc().unwrap(), RIFF_SIG);
+    let form_size = cursor.read_u32::<LittleEndian>().unwrap();
+    assert_eq!(cursor.read_fourcc().unwrap(), WAVE_SIG);
+
+    // The next chunk must be `fmt `, not `JUNK` — we skipped the
+    // ds64 reservation.
+    assert_eq!(cursor.read_fourcc().unwrap(), FMT__SIG);
+    let fmt_size = cursor.read_u32::<LittleEndian>().unwrap();
+    assert_eq!(form_size, 4 + 8 + fmt_size);
 }
 
 #[test]


### PR DESCRIPTION
First — thank you for bwavfile! It's been a great foundation for the broadcast-audio work we're doing at PRX (Public Radio Exchange), where we're wrapping MP2 audio in Broadcast Wave files for public-radio distribution in the US. Wrapping codec-encoded audio inside a WAV container is a slightly unusual use case, and the gaps below are minor — they only became visible because of that specific niche. The library handles the conventional PCM/RF64 broadcast workflow really well, and most of these changes are small ergonomic additions.

Bundling them into one PR since they're all related and each individual change is small. Happy to split if you'd prefer.

## Changes

### `pub mod parser` + `pub use FourCC, ChunkIteratorItem`
Exposes the chunk `Parser` publicly so consumers can walk arbitrary chunks beyond what `WaveReader`'s typed accessors expose. Useful for tooling that needs to inspect chunk layout (e.g. our round-trip verification tool).

### `WaveReader::read_data_chunk(&mut Vec<u8>)`
Public accessor for the raw bytes of the `data` chunk, mirroring the existing `read_ixml` / `read_axml` pattern. For PCM files this is sample bytes (and `audio_frame_reader` is the better path); for codec-encoded data it's the codec body, which a caller can hand to a separate decoder.

### `WaveWriter::new_without_ds64_reservation`
An opt-in alternative to `new()` that skips the 96-byte `JUNK` `ds64` reservation. The reservation is the right default for files whose final size is unknown, but for files guaranteed to stay under 4 GiB (such as the MP2 broadcast carts we generate, which top out at a few hundred MB) it adds bytes and visible drift from the byte layout of pre-existing broadcast tooling. Documented as not safe for RF64 promotion. The existing `new()` is unchanged — fully backward compatible.

### `AudioFrameReader::new` returns `Err(UnsupportedAudioFormat { tag })` for codec formats
Previously panicked on the PCM block-alignment assertion when given a non-PCM format. We hit this when accidentally asking `AudioFrameReader` to read an MPEG file's data chunk; a clean error felt more useful than a panic for a recoverable caller mistake.

Adds new error variant: `Error::UnsupportedAudioFormat { tag: u16 }`. This is technically a breaking change for code that exhaustively `match`es on `Error`, but `Error` already has many variants and exhaustive matching of it would be unusual. Behavior change for callers passing non-PCM formats: previously panicked, now returns `Err`.

### `#[derive(Clone)]` on `Bext`
Trivial additive change so callers can manipulate a `Bext` after passing one to a writer.

## Tests
- `test_new_without_ds64_reservation`: verifies the `JUNK` chunk is absent and `fmt` follows immediately after the `WAVE` header.
- `audio_frame_reader_rejects_unsupported_format_cleanly`: constructs a `WaveFmt` with MPEG tag (`0x0050`) and verifies `Err(UnsupportedAudioFormat { tag: 0x0050 })` instead of panic.

## Test plan
- [x] All existing tests continue to pass (`cargo test --lib --tests`)
- [x] Two new regression tests pass
- [x] `cargo fmt --check` clean