### PR TITLE
Add MPEG audio support: fact + mext chunks and MPEG-1 fmt extension (EBU Tech 3285 S1)

### DIFF
--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use super::bext::Bext;
 use super::errors::Error as ParserError;
 use super::fact::Fact;
-use super::fmt::{WaveFmt, WaveFmtExtended};
+use super::fmt::{WaveFmt, WaveFmtExtended, WaveFmtMpeg1};
 use super::mext::Mext;
 
 pub trait ReadBWaveChunks: Read {
@@ -36,6 +36,10 @@ where
     T: Write,
 {
     fn write_wave_fmt(&mut self, format: &WaveFmt) -> Result<(), ParserError> {
+        debug_assert!(
+            !(format.extended_format.is_some() && format.mpeg1_format.is_some()),
+            "WaveFmt has both extended_format and mpeg1_format set; these are mutually exclusive"
+        );
         self.write_u16::<LittleEndian>(format.tag)?;
         self.write_u16::<LittleEndian>(format.channel_count)?;
         self.write_u32::<LittleEndian>(format.sample_rate)?;
@@ -49,6 +53,18 @@ where
             self.write_u32::<LittleEndian>(ext.channel_mask)?;
             let uuid = ext.type_guid.as_bytes();
             self.write_all(uuid)?;
+        } else if let Some(mpeg1) = format.mpeg1_format {
+            // MPEG1WAVEFORMAT: cbSize = 22 (8 fields totaling 22 bytes after cbSize).
+            let cb_size = 22u16;
+            self.write_u16::<LittleEndian>(cb_size)?;
+            self.write_u16::<LittleEndian>(mpeg1.head_layer)?;
+            self.write_u32::<LittleEndian>(mpeg1.head_bit_rate)?;
+            self.write_u16::<LittleEndian>(mpeg1.head_mode)?;
+            self.write_u16::<LittleEndian>(mpeg1.head_mode_ext)?;
+            self.write_u16::<LittleEndian>(mpeg1.head_emphasis)?;
+            self.write_u16::<LittleEndian>(mpeg1.head_flags)?;
+            self.write_u32::<LittleEndian>(mpeg1.pts_low)?;
+            self.write_u32::<LittleEndian>(mpeg1.pts_high)?;
         }
         Ok(())
     }
@@ -144,6 +160,25 @@ where
                             self.read_exact(&mut buf)?;
                             Uuid::from_slice(&buf)?
                         },
+                    })
+                } else {
+                    None
+                }
+            },
+            mpeg1_format: {
+                // MPEG-1 audio (incl. MP2). EBU Tech 3285 Supplement 1, §2.1.
+                if tag_value == 0x0050 {
+                    let cb_size = self.read_u16::<LittleEndian>()?;
+                    assert!(cb_size >= 22, "MPEG-1 fmt extension is not correct size");
+                    Some(WaveFmtMpeg1 {
+                        head_layer: self.read_u16::<LittleEndian>()?,
+                        head_bit_rate: self.read_u32::<LittleEndian>()?,
+                        head_mode: self.read_u16::<LittleEndian>()?,
+                        head_mode_ext: self.read_u16::<LittleEndian>()?,
+                        head_emphasis: self.read_u16::<LittleEndian>()?,
+                        head_flags: self.read_u16::<LittleEndian>()?,
+                        pts_low: self.read_u32::<LittleEndian>()?,
+                        pts_high: self.read_u32::<LittleEndian>()?,
                     })
                 } else {
                     None

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -11,18 +11,21 @@ use uuid::Uuid;
 
 use super::bext::Bext;
 use super::errors::Error as ParserError;
+use super::fact::Fact;
 use super::fmt::{WaveFmt, WaveFmtExtended};
 
 pub trait ReadBWaveChunks: Read {
     fn read_bext(&mut self) -> Result<Bext, ParserError>;
     fn read_bext_string_field(&mut self, length: usize) -> Result<String, ParserError>;
     fn read_wave_fmt(&mut self) -> Result<WaveFmt, ParserError>;
+    fn read_fact(&mut self) -> Result<Fact, ParserError>;
 }
 
 pub trait WriteBWaveChunks: Write {
     fn write_wave_fmt(&mut self, format: &WaveFmt) -> Result<(), ParserError>;
     fn write_bext_string_field(&mut self, string: &str, length: usize) -> Result<(), ParserError>;
     fn write_bext(&mut self, bext: &Bext) -> Result<(), ParserError>;
+    fn write_fact(&mut self, fact: &Fact) -> Result<(), ParserError>;
 }
 
 impl<T> WriteBWaveChunks for T
@@ -92,6 +95,11 @@ where
             .expect("Error");
 
         self.write_all(&coding)?;
+        Ok(())
+    }
+
+    fn write_fact(&mut self, fact: &Fact) -> Result<(), ParserError> {
+        self.write_u32::<LittleEndian>(fact.sample_length)?;
         Ok(())
     }
 }
@@ -213,6 +221,12 @@ where
                     .decode(&buf, DecoderTrap::Ignore)
                     .expect("Error decoding text")
             },
+        })
+    }
+
+    fn read_fact(&mut self) -> Result<Fact, ParserError> {
+        Ok(Fact {
+            sample_length: self.read_u32::<LittleEndian>()?,
         })
     }
 }

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -13,12 +13,14 @@ use super::bext::Bext;
 use super::errors::Error as ParserError;
 use super::fact::Fact;
 use super::fmt::{WaveFmt, WaveFmtExtended};
+use super::mext::Mext;
 
 pub trait ReadBWaveChunks: Read {
     fn read_bext(&mut self) -> Result<Bext, ParserError>;
     fn read_bext_string_field(&mut self, length: usize) -> Result<String, ParserError>;
     fn read_wave_fmt(&mut self) -> Result<WaveFmt, ParserError>;
     fn read_fact(&mut self) -> Result<Fact, ParserError>;
+    fn read_mext(&mut self) -> Result<Mext, ParserError>;
 }
 
 pub trait WriteBWaveChunks: Write {
@@ -26,6 +28,7 @@ pub trait WriteBWaveChunks: Write {
     fn write_bext_string_field(&mut self, string: &str, length: usize) -> Result<(), ParserError>;
     fn write_bext(&mut self, bext: &Bext) -> Result<(), ParserError>;
     fn write_fact(&mut self, fact: &Fact) -> Result<(), ParserError>;
+    fn write_mext(&mut self, mext: &Mext) -> Result<(), ParserError>;
 }
 
 impl<T> WriteBWaveChunks for T
@@ -100,6 +103,15 @@ where
 
     fn write_fact(&mut self, fact: &Fact) -> Result<(), ParserError> {
         self.write_u32::<LittleEndian>(fact.sample_length)?;
+        Ok(())
+    }
+
+    fn write_mext(&mut self, mext: &Mext) -> Result<(), ParserError> {
+        self.write_u16::<LittleEndian>(mext.sound_information)?;
+        self.write_u16::<LittleEndian>(mext.frame_size)?;
+        self.write_u16::<LittleEndian>(mext.ancillary_data_length)?;
+        self.write_u16::<LittleEndian>(mext.ancillary_data_def)?;
+        self.write_all(&mext.reserved)?;
         Ok(())
     }
 }
@@ -227,6 +239,20 @@ where
     fn read_fact(&mut self) -> Result<Fact, ParserError> {
         Ok(Fact {
             sample_length: self.read_u32::<LittleEndian>()?,
+        })
+    }
+
+    fn read_mext(&mut self) -> Result<Mext, ParserError> {
+        Ok(Mext {
+            sound_information: self.read_u16::<LittleEndian>()?,
+            frame_size: self.read_u16::<LittleEndian>()?,
+            ancillary_data_length: self.read_u16::<LittleEndian>()?,
+            ancillary_data_def: self.read_u16::<LittleEndian>()?,
+            reserved: {
+                let mut buf = [0u8; 4];
+                self.read_exact(&mut buf)?;
+                buf
+            },
         })
     }
 }

--- a/src/fact.rs
+++ b/src/fact.rs
@@ -1,0 +1,59 @@
+/// `fact` chunk record.
+///
+/// Required for non-PCM data per [EBU Tech 3285 Supplement 1][s1]. The
+/// `fact` chunk carries the total number of samples per channel after
+/// decoding. For MPEG audio, this equals
+/// `frame_count * samples_per_frame`.
+///
+/// ## RF64 note
+///
+/// `dwSampleLength` is `u32`. For files exceeding 2^32 samples, the
+/// long sample count belongs in `ds64.factSampleLength` per ITU-R
+/// BS.2088 / EBU Tech 3306. The current `WaveWriter` does not yet
+/// route `fact` through `ds64`, so writing extreme-length non-PCM
+/// streams correctly is not supported. In practice this is unreachable
+/// for typical broadcast files, but a future RF64 enhancement may
+/// extend `Fact` accordingly.
+///
+/// ## Resources
+/// - [EBU Tech 3285 Supplement 1][s1]
+///
+/// [s1]: https://tech.ebu.ch/docs/tech/tech3285s1.pdf
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Fact {
+    /// Number of samples per channel after decoding.
+    pub sample_length: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chunks::{ReadBWaveChunks, WriteBWaveChunks};
+    use std::io::{Cursor, Seek, SeekFrom};
+
+    fn round_trip(sample_length: u32) {
+        let original = Fact { sample_length };
+        let mut buf = Cursor::new(Vec::<u8>::new());
+        buf.write_fact(&original).unwrap();
+        // fact chunk content is exactly 4 bytes (a u32)
+        assert_eq!(buf.get_ref().len(), 4);
+        buf.seek(SeekFrom::Start(0)).unwrap();
+        let parsed = buf.read_fact().unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn round_trip_zero() {
+        round_trip(0);
+    }
+
+    #[test]
+    fn round_trip_one() {
+        round_trip(1);
+    }
+
+    #[test]
+    fn round_trip_max() {
+        round_trip(u32::MAX);
+    }
+}

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -135,6 +135,57 @@ pub struct WaveFmtExtended {
     pub type_guid: Uuid,
 }
 
+/// MPEG-1 Wave Format extension (`MPEG1WAVEFORMAT`).
+///
+/// Present in WAVE files whose [`WaveFmt::tag`] is `0x0050` (MPEG-1
+/// audio, including MPEG-1 Layer II / MP2), as defined by EBU Tech 3285
+/// Supplement 1. Carries MPEG-specific framing information that the
+/// standard `fmt` chunk cannot express.
+///
+/// Mutually exclusive with [`WaveFmtExtended`]: only one of
+/// [`WaveFmt::extended_format`] and [`WaveFmt::mpeg1_format`] is ever
+/// `Some` for a given file. The `tag` field selects which.
+///
+/// All fields are little-endian, despite the MPEG bitstream itself
+/// being big-endian — the WAVE container places this struct in RIFF
+/// byte order.
+///
+/// ## Resources
+/// - [EBU Tech 3285 Supplement 1](https://tech.ebu.ch/docs/tech/tech3285s1.pdf), §2.1
+/// - [MPEG1WAVEFORMAT](https://learn.microsoft.com/en-us/previous-versions/dd757717(v=vs.85))
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct WaveFmtMpeg1 {
+    /// MPEG audio layer flag (`ACM_MPEG_LAYER1`=1, `LAYER2`=2, `LAYER3`=4).
+    pub head_layer: u16,
+
+    /// Average bit rate in **bits per second** (not kbps).
+    pub head_bit_rate: u32,
+
+    /// Channel mode flag (`ACM_MPEG_STEREO`=1, `JOINTSTEREO`=2,
+    /// `DUALCHANNEL`=4, `SINGLECHANNEL`=8).
+    pub head_mode: u16,
+
+    /// Mode extension (only meaningful when `head_mode` indicates
+    /// joint stereo).
+    pub head_mode_ext: u16,
+
+    /// Audio emphasis flag (per ACM, 1-indexed: 1=none, 2=50/15µs,
+    /// 3=reserved, 4=CCIT J.17).
+    pub head_emphasis: u16,
+
+    /// Bitfield of per-frame flags (CRC, copyright, original,
+    /// padding, etc.).
+    pub head_flags: u16,
+
+    /// Low 32 bits of the presentation time stamp (PTS), in 90 kHz
+    /// units.
+    pub pts_low: u32,
+
+    /// High 32 bits of the presentation time stamp (PTS), in 90 kHz
+    /// units.
+    pub pts_high: u32,
+}
+
 ///
 /// WAV file data format record.
 ///
@@ -201,7 +252,18 @@ pub struct WaveFmt {
     ///
     /// Additional format metadata if channel_count is greater than 2,
     /// or if certain codecs are used.
+    ///
+    /// Mutually exclusive with [`mpeg1_format`](Self::mpeg1_format):
+    /// at most one of these is `Some` for a given file. `tag == 0xFFFE`
+    /// selects this variant.
     pub extended_format: Option<WaveFmtExtended>,
+
+    /// MPEG-1 audio format extension (`MPEG1WAVEFORMAT`).
+    ///
+    /// Present when `tag == 0x0050` (MPEG-1 audio, e.g. MP2). Defined
+    /// by EBU Tech 3285 Supplement 1. Mutually exclusive with
+    /// [`extended_format`](Self::extended_format).
+    pub mpeg1_format: Option<WaveFmtMpeg1>,
 }
 
 impl WaveFmt {
@@ -211,6 +273,13 @@ impl WaveFmt {
         } else {
             self.bits_per_sample
         }
+    }
+
+    /// MPEG-1 format extension if this `fmt` chunk describes MPEG-1 audio.
+    ///
+    /// Returns `Some` for files where `tag == 0x0050`, `None` otherwise.
+    pub fn mpeg1_extension(&self) -> Option<&WaveFmtMpeg1> {
+        self.mpeg1_format.as_ref()
     }
 
     /// Create a new integer PCM format for a monoaural audio stream.
@@ -243,6 +312,7 @@ impl WaveFmt {
                 channel_mask: ChannelMask::DirectOut as u32,
                 type_guid: WAVE_UUID_BFORMAT_PCM,
             }),
+            mpeg1_format: None,
         }
     }
 
@@ -296,6 +366,7 @@ impl WaveFmt {
             block_alignment: container_bytes_per_sample * channel_count,
             bits_per_sample: container_bits_per_sample,
             extended_format: extformat,
+            mpeg1_format: None,
         }
     }
 
@@ -443,5 +514,79 @@ where
     }
     fn write_f32_frames(&mut self, _format: WaveFmt, _: &[f32]) -> Result<usize, std::io::Error> {
         todo!()
+    }
+}
+
+#[cfg(test)]
+mod mpeg1_tests {
+    use super::*;
+    use crate::chunks::{ReadBWaveChunks, WriteBWaveChunks};
+    use std::io::{Cursor, Seek, SeekFrom};
+
+    fn sample_mpeg1_fmt() -> WaveFmt {
+        WaveFmt {
+            tag: 0x0050,
+            channel_count: 2,
+            sample_rate: 44100,
+            bytes_per_second: 32000,
+            block_alignment: 836,
+            // EBU 3285-S1 sentinel for MPEG audio: bits_per_sample is
+            // typically 0xFFFF (or 0; both are seen in the wild).
+            bits_per_sample: 0xFFFF,
+            extended_format: None,
+            mpeg1_format: Some(WaveFmtMpeg1 {
+                head_layer: 2, // ACM_MPEG_LAYER2 = 2
+                head_bit_rate: 256_000,
+                head_mode: 1, // ACM_MPEG_STEREO = 1
+                head_mode_ext: 0,
+                head_emphasis: 1, // ACM_MPEG_NONE = 1
+                head_flags: 0,
+                pts_low: 0,
+                pts_high: 0,
+            }),
+        }
+    }
+
+    #[test]
+    fn mpeg1_fmt_round_trip_via_chunks_traits() {
+        let original = sample_mpeg1_fmt();
+        let mut buf = Cursor::new(Vec::<u8>::new());
+        buf.write_wave_fmt(&original).unwrap();
+        // Base 16 + cb_size 2 + 22-byte MPEG-1 extension = 40 bytes
+        assert_eq!(buf.get_ref().len(), 40);
+        buf.seek(SeekFrom::Start(0)).unwrap();
+        let parsed = buf.read_wave_fmt().unwrap();
+
+        assert_eq!(parsed.tag, original.tag);
+        assert_eq!(parsed.channel_count, original.channel_count);
+        assert_eq!(parsed.sample_rate, original.sample_rate);
+        assert_eq!(parsed.bytes_per_second, original.bytes_per_second);
+        assert_eq!(parsed.block_alignment, original.block_alignment);
+        assert_eq!(parsed.bits_per_sample, original.bits_per_sample);
+        assert!(parsed.extended_format.is_none());
+        assert_eq!(parsed.mpeg1_format, original.mpeg1_format);
+    }
+
+    #[test]
+    fn mpeg1_extension_accessor() {
+        let f = sample_mpeg1_fmt();
+        assert!(f.mpeg1_extension().is_some());
+        assert_eq!(f.mpeg1_extension().unwrap().head_layer, 2);
+
+        let pcm = WaveFmt::new_pcm_mono(48000, 24);
+        assert!(pcm.mpeg1_extension().is_none());
+        assert!(pcm.mpeg1_format.is_none());
+    }
+
+    #[test]
+    fn pcm_constructors_set_mpeg1_format_to_none() {
+        assert!(WaveFmt::new_pcm_mono(48000, 24).mpeg1_format.is_none());
+        assert!(WaveFmt::new_pcm_stereo(48000, 16).mpeg1_format.is_none());
+        assert!(WaveFmt::new_pcm_multichannel(48000, 24, 0x3F)
+            .mpeg1_format
+            .is_none());
+        assert!(WaveFmt::new_pcm_ambisonic(48000, 24, 4)
+            .mpeg1_format
+            .is_none());
     }
 }

--- a/src/fourcc.rs
+++ b/src/fourcc.rs
@@ -121,6 +121,7 @@ pub const FMT__SIG: FourCC = FourCC::make(b"fmt ");
 
 pub const BEXT_SIG: FourCC = FourCC::make(b"bext");
 pub const FACT_SIG: FourCC = FourCC::make(b"fact");
+pub const MEXT_SIG: FourCC = FourCC::make(b"mext");
 pub const IXML_SIG: FourCC = FourCC::make(b"iXML");
 pub const AXML_SIG: FourCC = FourCC::make(b"axml");
 

--- a/src/fourcc.rs
+++ b/src/fourcc.rs
@@ -120,7 +120,7 @@ pub const DATA_SIG: FourCC = FourCC::make(b"data");
 pub const FMT__SIG: FourCC = FourCC::make(b"fmt ");
 
 pub const BEXT_SIG: FourCC = FourCC::make(b"bext");
-//pub const FACT_SIG: FourCC = FourCC::make(b"fact");
+pub const FACT_SIG: FourCC = FourCC::make(b"fact");
 pub const IXML_SIG: FourCC = FourCC::make(b"iXML");
 pub const AXML_SIG: FourCC = FourCC::make(b"axml");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ mod chunks;
 mod cue;
 mod fact;
 mod fmt;
+mod mext;
 
 mod sample;
 
@@ -55,6 +56,7 @@ pub use fact::Fact;
 pub use fmt::{
     ADMAudioID, ChannelDescriptor, ChannelMask, ReadWavAudioData, WaveFmt, WaveFmtExtended,
 };
+pub use mext::Mext;
 pub use sample::{Sample, I24};
 pub use wavereader::{AudioFrameReader, WaveReader};
 pub use wavewriter::{AudioFrameWriter, WaveWriter};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub use errors::Error;
 pub use fact::Fact;
 pub use fmt::{
     ADMAudioID, ChannelDescriptor, ChannelMask, ReadWavAudioData, WaveFmt, WaveFmtExtended,
+    WaveFmtMpeg1,
 };
 pub use mext::Mext;
 pub use sample::{Sample, I24};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ mod parser;
 mod bext;
 mod chunks;
 mod cue;
+mod fact;
 mod fmt;
 
 mod sample;
@@ -50,6 +51,7 @@ pub use common_format::{
 };
 pub use cue::Cue;
 pub use errors::Error;
+pub use fact::Fact;
 pub use fmt::{
     ADMAudioID, ChannelDescriptor, ChannelMask, ReadWavAudioData, WaveFmt, WaveFmtExtended,
 };

--- a/src/mext.rs
+++ b/src/mext.rs
@@ -1,0 +1,126 @@
+/// `mext` chunk record — MPEG audio extension for Broadcast Wave Files.
+///
+/// Defined by [EBU Tech 3285 Supplement 1][s1] for files containing
+/// MPEG audio in the `data` chunk. Carries information about the
+/// framing of the MPEG bitstream that cannot be expressed in the
+/// standard `fmt` chunk: whether all frames are homogeneous, padding-
+/// bit usage, sample-rate locking, free-format detection, and
+/// ancillary-data region size.
+///
+/// Total chunk content size is exactly **12 bytes** (plus 8 bytes of
+/// chunk header in the WAVE container).
+///
+/// All fields are little-endian, despite the MPEG bitstream itself
+/// being big-endian — the EBU specification places `mext` in the
+/// surrounding RIFF byte order.
+///
+/// ## Resources
+/// - [EBU Tech 3285 Supplement 1][s1]
+///
+/// [s1]: https://tech.ebu.ch/docs/tech/tech3285s1.pdf
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Mext {
+    /// Bitfield describing the MPEG bitstream's framing properties.
+    /// See the `SOUND_*` flag constants on this type.
+    pub sound_information: u16,
+
+    /// Size in bytes of an MPEG audio frame, when the bitstream is
+    /// homogeneous (all frames the same size).
+    ///
+    /// Should equal the WAVE `fmt` chunk's `block_alignment` for
+    /// homogeneous streams.
+    pub frame_size: u16,
+
+    /// Length in bytes of the ancillary data region within each MPEG
+    /// frame, if any (0 if absent or unknown).
+    pub ancillary_data_length: u16,
+
+    /// Bitfield describing the type/usage of ancillary data, per
+    /// EBU Tech 3285 Supplement 1.
+    pub ancillary_data_def: u16,
+
+    /// Reserved 4 bytes; round-trip verbatim for forward compatibility
+    /// with future EBU additions.
+    pub reserved: [u8; 4],
+}
+
+/// `sound_information` bitfield flags (EBU Tech 3285 Supplement 1).
+impl Mext {
+    /// Bit 0: all frames in the file are homogeneous (same frame
+    /// size, sample rate, channel count, etc.).
+    pub const SOUND_HOMOGENEOUS: u16 = 0x0001;
+
+    /// Bit 1: the MPEG padding bit is never set in this file.
+    /// Only meaningful when [`SOUND_HOMOGENEOUS`](Self::SOUND_HOMOGENEOUS) is set.
+    pub const SOUND_PADDING_BIT_UNUSED: u16 = 0x0002;
+
+    /// Bit 2: file uses padding (e.g. 44.1 kHz / 22.05 kHz CBR
+    /// streams that use padding to keep the average bitrate exact).
+    pub const SOUND_PADDING_BIT_USED: u16 = 0x0004;
+
+    /// Bit 3: file uses MPEG free format (no fixed bitrate).
+    pub const SOUND_FREE_FORMAT: u16 = 0x0008;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chunks::{ReadBWaveChunks, WriteBWaveChunks};
+    use std::io::{Cursor, Seek, SeekFrom};
+
+    fn round_trip(mext: Mext) {
+        let mut buf = Cursor::new(Vec::<u8>::new());
+        buf.write_mext(&mext).unwrap();
+        assert_eq!(buf.get_ref().len(), 12, "mext content must be 12 bytes");
+        buf.seek(SeekFrom::Start(0)).unwrap();
+        let parsed = buf.read_mext().unwrap();
+        assert_eq!(parsed, mext);
+    }
+
+    #[test]
+    fn round_trip_zeros() {
+        round_trip(Mext {
+            sound_information: 0,
+            frame_size: 0,
+            ancillary_data_length: 0,
+            ancillary_data_def: 0,
+            reserved: [0; 4],
+        });
+    }
+
+    #[test]
+    fn round_trip_all_sound_information_combinations() {
+        // All 16 combinations of the 4 defined sound_information bits.
+        for bits in 0u16..16 {
+            round_trip(Mext {
+                sound_information: bits,
+                frame_size: 144,
+                ancillary_data_length: 0,
+                ancillary_data_def: 0,
+                reserved: [0; 4],
+            });
+        }
+    }
+
+    #[test]
+    fn round_trip_max_values() {
+        round_trip(Mext {
+            sound_information: u16::MAX,
+            frame_size: u16::MAX,
+            ancillary_data_length: u16::MAX,
+            ancillary_data_def: u16::MAX,
+            reserved: [0xFF; 4],
+        });
+    }
+
+    #[test]
+    fn reserved_bytes_round_trip_verbatim() {
+        round_trip(Mext {
+            sound_information: 0,
+            frame_size: 0,
+            ancillary_data_length: 0,
+            ancillary_data_def: 0,
+            reserved: [0xDE, 0xAD, 0xBE, 0xEF],
+        });
+    }
+}

--- a/src/wavereader.rs
+++ b/src/wavereader.rs
@@ -16,8 +16,9 @@ use super::fact::Fact;
 use super::fmt::{ChannelDescriptor, ChannelMask, WaveFmt};
 use super::fourcc::{
     FourCC, ReadFourCC, ADTL_SIG, AXML_SIG, BEXT_SIG, CUE__SIG, DATA_SIG, FACT_SIG, FLLR_SIG,
-    FMT__SIG, IXML_SIG, JUNK_SIG, LIST_SIG,
+    FMT__SIG, IXML_SIG, JUNK_SIG, LIST_SIG, MEXT_SIG,
 };
+use super::mext::Mext;
 use super::parser::Parser;
 use super::{CommonFormat, Sample, I24};
 
@@ -327,6 +328,21 @@ impl<R: Read + Seek> WaveReader<R> {
         if result > 0 {
             let mut cursor = Cursor::new(buf);
             Ok(Some(cursor.read_fact()?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// The `mext` (MPEG audio extension) chunk for this file, if present.
+    ///
+    /// Required alongside the MPEG-extended `fmt` chunk for files
+    /// containing MPEG audio per EBU Tech 3285 Supplement 1.
+    pub fn mext(&mut self) -> Result<Option<Mext>, ParserError> {
+        let mut buf: Vec<u8> = vec![];
+        let result = self.read_chunk(MEXT_SIG, 0, &mut buf)?;
+        if result > 0 {
+            let mut cursor = Cursor::new(buf);
+            Ok(Some(cursor.read_mext()?))
         } else {
             Ok(None)
         }

--- a/src/wavereader.rs
+++ b/src/wavereader.rs
@@ -12,10 +12,11 @@ use super::chunks::ReadBWaveChunks;
 use super::cue::Cue;
 use super::errors::Error as ParserError;
 use super::errors::Error;
+use super::fact::Fact;
 use super::fmt::{ChannelDescriptor, ChannelMask, WaveFmt};
 use super::fourcc::{
-    FourCC, ReadFourCC, ADTL_SIG, AXML_SIG, BEXT_SIG, CUE__SIG, DATA_SIG, FLLR_SIG, FMT__SIG,
-    IXML_SIG, JUNK_SIG, LIST_SIG,
+    FourCC, ReadFourCC, ADTL_SIG, AXML_SIG, BEXT_SIG, CUE__SIG, DATA_SIG, FACT_SIG, FLLR_SIG,
+    FMT__SIG, IXML_SIG, JUNK_SIG, LIST_SIG,
 };
 use super::parser::Parser;
 use super::{CommonFormat, Sample, I24};
@@ -312,6 +313,20 @@ impl<R: Read + Seek> WaveReader<R> {
         if result > 0 {
             let mut bext_cursor = Cursor::new(bext_buff);
             Ok(Some(bext_cursor.read_bext()?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// The `fact` chunk for this file, if present.
+    ///
+    /// Required for non-PCM data per EBU Tech 3285 Supplement 1.
+    pub fn fact(&mut self) -> Result<Option<Fact>, ParserError> {
+        let mut buf: Vec<u8> = vec![];
+        let result = self.read_chunk(FACT_SIG, 0, &mut buf)?;
+        if result > 0 {
+            let mut cursor = Cursor::new(buf);
+            Ok(Some(cursor.read_fact()?))
         } else {
             Ok(None)
         }

--- a/src/wavewriter.rs
+++ b/src/wavewriter.rs
@@ -6,13 +6,14 @@ use crate::CommonFormat;
 
 use super::fmt::WaveFmt;
 use super::fourcc::{
-    FourCC, WriteFourCC, AXML_SIG, BEXT_SIG, DATA_SIG, DS64_SIG, ELM1_SIG, FMT__SIG, IXML_SIG,
-    JUNK_SIG, RF64_SIG, RIFF_SIG, WAVE_SIG,
+    FourCC, WriteFourCC, AXML_SIG, BEXT_SIG, DATA_SIG, DS64_SIG, ELM1_SIG, FACT_SIG, FMT__SIG,
+    IXML_SIG, JUNK_SIG, RF64_SIG, RIFF_SIG, WAVE_SIG,
 };
 use super::{Error, Sample, I24};
 //use super::common_format::CommonFormat;
 use super::bext::Bext;
 use super::chunks::WriteBWaveChunks;
+use super::fact::Fact;
 
 use byteorder::LittleEndian;
 use byteorder::WriteBytesExt;
@@ -359,6 +360,17 @@ where
         c.write_bext(bext)?;
         let buf = c.into_inner();
         self.write_chunk(BEXT_SIG, &buf)?;
+        Ok(())
+    }
+
+    /// Write a `fact` chunk to the file.
+    ///
+    /// Required for non-PCM data per EBU Tech 3285 Supplement 1.
+    pub fn write_fact(&mut self, fact: &Fact) -> Result<(), Error> {
+        let mut c = Cursor::new(vec![0u8; 0]);
+        c.write_fact(fact)?;
+        let buf = c.into_inner();
+        self.write_chunk(FACT_SIG, &buf)?;
         Ok(())
     }
 

--- a/src/wavewriter.rs
+++ b/src/wavewriter.rs
@@ -7,13 +7,14 @@ use crate::CommonFormat;
 use super::fmt::WaveFmt;
 use super::fourcc::{
     FourCC, WriteFourCC, AXML_SIG, BEXT_SIG, DATA_SIG, DS64_SIG, ELM1_SIG, FACT_SIG, FMT__SIG,
-    IXML_SIG, JUNK_SIG, RF64_SIG, RIFF_SIG, WAVE_SIG,
+    IXML_SIG, JUNK_SIG, MEXT_SIG, RF64_SIG, RIFF_SIG, WAVE_SIG,
 };
 use super::{Error, Sample, I24};
 //use super::common_format::CommonFormat;
 use super::bext::Bext;
 use super::chunks::WriteBWaveChunks;
 use super::fact::Fact;
+use super::mext::Mext;
 
 use byteorder::LittleEndian;
 use byteorder::WriteBytesExt;
@@ -371,6 +372,18 @@ where
         c.write_fact(fact)?;
         let buf = c.into_inner();
         self.write_chunk(FACT_SIG, &buf)?;
+        Ok(())
+    }
+
+    /// Write an `mext` (MPEG audio extension) chunk to the file.
+    ///
+    /// Required alongside the MPEG-extended `fmt` chunk for files
+    /// containing MPEG audio per EBU Tech 3285 Supplement 1.
+    pub fn write_mext(&mut self, mext: &Mext) -> Result<(), Error> {
+        let mut c = Cursor::new(vec![0u8; 0]);
+        c.write_mext(mext)?;
+        let buf = c.into_inner();
+        self.write_chunk(MEXT_SIG, &buf)?;
         Ok(())
     }
 


### PR DESCRIPTION
Adds support for the three chunks defined by [EBU Tech 3285 Supplement 1](https://tech.ebu.ch/docs/tech/tech3285s1.pdf) (1997) for embedding MPEG audio in Broadcast Wave files. These three pieces are mutually dependent — every MPEG-in-WAV file uses all three together — so they hang well as a single PR.

Context: this is part of work at PRX (Public Radio Exchange) for wrapping MP2 audio in BWF for public-radio distribution in the US. Thank you for `bwavfile` — the chunk-event-stream parser made adding new chunk types delightfully easy.

Three commits, one per chunk:

## 1. `fact` chunk
4 bytes carrying a `u32` sample_length (total decoded samples per channel). Required for any non-PCM data per EBU 3285 S1; for MPEG audio the value is `frame_count * samples_per_frame`.

- `Fact` struct in new `src/fact.rs`
- `read_fact` / `write_fact` on the existing chunks traits
- `WaveReader::fact()` and `WaveWriter::write_fact()`, mirroring the `broadcast_extension()` pattern
- `FACT_SIG` (was already declared in fourcc.rs, just commented out)

Round-trip tests at `u32` edges. Documented limitation: RF64 files exceeding 2^32 decoded samples should route the long count through `ds64.factSampleLength` per EBU 3306, which the current `WaveWriter` doesn't yet do — flagged in the rustdoc.

## 2. `mext` chunk
12 bytes carrying MPEG-specific framing info that the standard `fmt` chunk can't express: homogeneity, padding-bit usage, sample-rate locking, free-format detection, ancillary-data region.

- `Mext` struct + `SOUND_*` bitfield constants in new `src/mext.rs`
- `read_mext` / `write_mext` on the chunks traits
- `WaveReader::mext()` and `WaveWriter::write_mext()`
- `MEXT_SIG`

Round-trip tests cover all 16 `sound_information` bit combinations plus a non-ASCII reserved-byte pattern (the 4 reserved bytes are stored as `[u8; 4]` for byte-exact preservation).

## 3. MPEG-1 fmt extension (`MPEG1WAVEFORMAT`)
The most involved piece. WAVE files with `tag = 0x0050` carry an extension after the standard `WAVEFORMATEX` — 8 codec-specific fields totaling 22 bytes after `cbSize`.

The design question was how to add this to `WaveFmt`. The structurally-correct sum type would be an enum (one variant for `WAVEFORMATEXTENSIBLE`, one for `MPEG1WAVEFORMAT`), but that would break every existing caller of `WaveFmt::valid_bits_per_sample()`, `ChannelMask::channels(ext.channel_mask, ...)`, `common_format()`, etc. Instead this PR adds a parallel `Option<WaveFmtMpeg1>` field alongside the existing `Option<WaveFmtExtended>`:

- The two are mutually exclusive in practice (`tag` selects which is populated)
- Documented in rustdoc, enforced by a `debug_assert` in the writer
- Purely additive: every existing caller keeps compiling unchanged
- PCM constructors updated with `mpeg1_format: None`

Tests cover round-trip through the chunks traits (40-byte total: 16 base + 2 cbSize + 22 extension), the `mpeg1_extension()` accessor, and that all PCM constructors leave `mpeg1_format` as `None`.

## Test plan
- [x] All upstream tests continue to pass (`cargo test --lib --tests`)
- [x] Three new test modules: 3 fact tests, 4 mext tests, 3 MPEG-1 fmt tests — all passing
- [x] `cargo fmt --check` clean