### PR TITLE
Add cart chunk read/write support (AES46-2002)

### DIFF
--- a/src/cart.rs
+++ b/src/cart.rs
@@ -1,0 +1,296 @@
+use crate::fourcc::FourCC;
+
+/// `cart` chunk PostTimer entry.
+///
+/// Each `Cart` has exactly 8 of these. Unused entries should have a
+/// zero `usage` FourCC.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
+pub struct CartTimer {
+    /// 4-character usage code identifying what this timer marks
+    /// (e.g. `b"AUDs"`, `b"INT1"`, `b"EOD "`). Zero FourCC means unused.
+    pub usage: FourCC,
+
+    /// Sample-offset value associated with this timer.
+    pub value: u32,
+}
+
+/// `cart` chunk record — broadcast-automation cart metadata
+/// (AES46-2002, "Audio cart chunk for AES46-2002 cartridge labels").
+///
+/// The chunk carries title/artist/category metadata, scheduling
+/// timestamps, level reference, post-roll timer marks, and free-form
+/// tag text used by broadcast automation systems for scheduling and
+/// playback of audio carts.
+///
+/// # Layout
+///
+/// The chunk has a fixed 2048-byte base for `Version >= "0101"` plus a
+/// variable-length `tag_text` trailer. The legacy `"0000"` version
+/// omits the 1024-byte URL field (1024-byte base instead of 2048).
+///
+/// All ASCII string fields are NUL-padded within their fixed slot. The
+/// 276-byte `reserved` blob round-trips byte-exact for forward
+/// compatibility with vendor extensions; it is **not** decoded as a
+/// string (the AES46-2002 specification deliberately permits arbitrary
+/// bytes here).
+///
+/// `level_reference` is **signed** (`i32`) per AES46-2002 §5.2.16, in
+/// units of dB × 100 relative to digital full scale.
+///
+/// All multi-byte numeric fields are little-endian.
+///
+/// # Resources
+/// - [AES46-2002 Cart Chunk overview](http://www.cartchunk.org/)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Cart {
+    /// Cart chunk version, 4 ASCII characters (e.g. `"0101"`).
+    /// `"0000"` is a legacy format that omits the URL field.
+    pub version: String,
+
+    /// Cart title (max 64 ASCII chars).
+    pub title: String,
+
+    /// Performer / artist (max 64 ASCII chars).
+    pub artist: String,
+
+    /// Cut identifier (max 64 ASCII chars).
+    pub cut_id: String,
+
+    /// Client identifier (max 64 ASCII chars).
+    pub client_id: String,
+
+    /// Category (max 64 ASCII chars).
+    pub category: String,
+
+    /// Classification (max 64 ASCII chars).
+    pub classification: String,
+
+    /// Out cue text (max 64 ASCII chars).
+    pub out_cue: String,
+
+    /// Start date (10 ASCII chars, typically `YYYY-MM-DD`).
+    pub start_date: String,
+
+    /// Start time (8 ASCII chars, typically `HH:MM:SS`).
+    pub start_time: String,
+
+    /// End date (10 ASCII chars, typically `YYYY-MM-DD`).
+    pub end_date: String,
+
+    /// End time (8 ASCII chars, typically `HH:MM:SS`).
+    pub end_time: String,
+
+    /// Producer application identifier (max 64 ASCII chars).
+    pub producer_app_id: String,
+
+    /// Producer application version (max 64 ASCII chars).
+    pub producer_app_version: String,
+
+    /// User-defined field (max 64 ASCII chars).
+    pub user_def: String,
+
+    /// Reference level, signed, in dB × 100 relative to digital full scale.
+    pub level_reference: i32,
+
+    /// Eight post-roll timer entries.
+    pub post_timers: [CartTimer; 8],
+
+    /// 276 reserved bytes that must round-trip byte-exact.
+    pub reserved: [u8; 276],
+
+    /// URL (max 1024 ASCII chars). Absent (empty string written/read)
+    /// for legacy `"0000"` version.
+    pub url: String,
+
+    /// Variable-length free-form tag text. Total cart chunk size is
+    /// `2048 + tag_text.len()` (or `1024 + tag_text.len()` for `"0000"`).
+    /// No NUL padding.
+    pub tag_text: String,
+}
+
+impl Default for Cart {
+    fn default() -> Self {
+        Cart {
+            version: "0101".to_string(),
+            title: String::new(),
+            artist: String::new(),
+            cut_id: String::new(),
+            client_id: String::new(),
+            category: String::new(),
+            classification: String::new(),
+            out_cue: String::new(),
+            start_date: String::new(),
+            start_time: String::new(),
+            end_date: String::new(),
+            end_time: String::new(),
+            producer_app_id: String::new(),
+            producer_app_version: String::new(),
+            user_def: String::new(),
+            level_reference: 0,
+            post_timers: <[CartTimer; 8]>::default(),
+            reserved: [0u8; 276],
+            url: String::new(),
+            tag_text: String::new(),
+        }
+    }
+}
+
+impl Cart {
+    /// True if this is a legacy `"0000"` cart with no URL field.
+    pub fn is_legacy_v0(&self) -> bool {
+        self.version == "0000"
+    }
+
+    /// Size in bytes of the fixed (non-tag-text) portion of the cart
+    /// chunk for this cart's version.
+    ///
+    /// Returns `1024` for `"0000"`, `2048` for everything else.
+    pub fn fixed_size(&self) -> u64 {
+        if self.is_legacy_v0() {
+            1024
+        } else {
+            2048
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chunks::{ReadBWaveChunks, WriteBWaveChunks};
+    use crate::fourcc::FourCC;
+    use std::io::{Cursor, Seek, SeekFrom};
+
+    fn round_trip(cart: Cart) {
+        let mut buf = Cursor::new(Vec::<u8>::new());
+        buf.write_cart(&cart).unwrap();
+        let total_size = cart.fixed_size() as usize + cart.tag_text.len();
+        assert_eq!(
+            buf.get_ref().len(),
+            total_size,
+            "cart chunk content size mismatch"
+        );
+        buf.seek(SeekFrom::Start(0)).unwrap();
+        let parsed = buf.read_cart(total_size as u64).unwrap();
+        assert_eq!(parsed, cart);
+    }
+
+    #[test]
+    fn round_trip_default() {
+        round_trip(Cart::default());
+    }
+
+    #[test]
+    fn round_trip_fully_populated() {
+        let cart = Cart {
+            version: "0101".to_string(),
+            title: "Test Cart".to_string(),
+            artist: "Test Artist".to_string(),
+            cut_id: "CUT-12345".to_string(),
+            client_id: "CLIENT-X".to_string(),
+            category: "NEWS".to_string(),
+            classification: "PROMO".to_string(),
+            out_cue: "...thanks for listening".to_string(),
+            start_date: "2026-05-01".to_string(),
+            start_time: "12:00:00".to_string(),
+            end_date: "2026-12-31".to_string(),
+            end_time: "23:59:59".to_string(),
+            producer_app_id: "bwavfile".to_string(),
+            producer_app_version: "0.0.0".to_string(),
+            user_def: "user defined data".to_string(),
+            level_reference: 8195,
+            post_timers: [
+                CartTimer {
+                    usage: FourCC::make(b"AUDs"),
+                    value: 0,
+                },
+                CartTimer {
+                    usage: FourCC::make(b"INT1"),
+                    value: 1234,
+                },
+                CartTimer {
+                    usage: FourCC::make(b"INT2"),
+                    value: 5678,
+                },
+                CartTimer {
+                    usage: FourCC::make(b"SEC1"),
+                    value: 90123,
+                },
+                CartTimer {
+                    usage: FourCC::make(b"EOD "),
+                    value: u32::MAX,
+                },
+                CartTimer::default(),
+                CartTimer::default(),
+                CartTimer::default(),
+            ],
+            reserved: [0u8; 276],
+            url: "https://example.com/cart".to_string(),
+            tag_text: "Free-form tag text\r\nMultiple lines OK\r\n".to_string(),
+        };
+        round_trip(cart);
+    }
+
+    #[test]
+    fn level_reference_signed_extremes() {
+        for value in [i32::MIN, -1, 0, 1, i32::MAX] {
+            round_trip(Cart {
+                level_reference: value,
+                ..Cart::default()
+            });
+        }
+    }
+
+    #[test]
+    fn reserved_bytes_round_trip_verbatim() {
+        // Fill reserved with non-ASCII pattern to verify byte-exact
+        // round-trip — the 276 reserved bytes are preserved as raw
+        // bytes (not decoded as a string), so vendor extensions that
+        // store arbitrary bytes there survive a read+write cycle.
+        let mut reserved = [0u8; 276];
+        for (i, byte) in reserved.iter_mut().enumerate() {
+            *byte = (i as u8).wrapping_mul(7).wrapping_add(0x80);
+        }
+        round_trip(Cart {
+            reserved,
+            ..Cart::default()
+        });
+    }
+
+    #[test]
+    fn tag_text_empty() {
+        let cart = Cart::default();
+        assert!(cart.tag_text.is_empty());
+        round_trip(cart);
+    }
+
+    #[test]
+    fn tag_text_odd_length() {
+        // Odd-length tag_text triggers the RIFF pad-byte path in the
+        // outer chunk writer; here we just verify the cart trailer
+        // itself round-trips at odd length.
+        round_trip(Cart {
+            tag_text: "x".repeat(7),
+            ..Cart::default()
+        });
+    }
+
+    #[test]
+    fn tag_text_long() {
+        round_trip(Cart {
+            tag_text: "y".repeat(8192),
+            ..Cart::default()
+        });
+    }
+
+    #[test]
+    fn legacy_v0000_omits_url() {
+        let cart = Cart {
+            version: "0000".to_string(),
+            // URL field is absent in v0000; default url is already empty.
+            ..Cart::default()
+        };
+        assert_eq!(cart.fixed_size(), 1024);
+        round_trip(cart);
+    }
+}

--- a/src/chunks.rs
+++ b/src/chunks.rs
@@ -10,19 +10,23 @@ use byteorder::{ReadBytesExt, WriteBytesExt};
 use uuid::Uuid;
 
 use super::bext::Bext;
+use super::cart::{Cart, CartTimer};
 use super::errors::Error as ParserError;
 use super::fmt::{WaveFmt, WaveFmtExtended};
+use super::fourcc::{FourCC, WriteFourCC};
 
 pub trait ReadBWaveChunks: Read {
     fn read_bext(&mut self) -> Result<Bext, ParserError>;
     fn read_bext_string_field(&mut self, length: usize) -> Result<String, ParserError>;
     fn read_wave_fmt(&mut self) -> Result<WaveFmt, ParserError>;
+    fn read_cart(&mut self, chunk_size: u64) -> Result<Cart, ParserError>;
 }
 
 pub trait WriteBWaveChunks: Write {
     fn write_wave_fmt(&mut self, format: &WaveFmt) -> Result<(), ParserError>;
     fn write_bext_string_field(&mut self, string: &str, length: usize) -> Result<(), ParserError>;
     fn write_bext(&mut self, bext: &Bext) -> Result<(), ParserError>;
+    fn write_cart(&mut self, cart: &Cart) -> Result<(), ParserError>;
 }
 
 impl<T> WriteBWaveChunks for T
@@ -91,6 +95,45 @@ where
             .encode(&bext.coding_history, EncoderTrap::Ignore)
             .expect("Error");
 
+        self.write_all(&coding)?;
+        Ok(())
+    }
+
+    fn write_cart(&mut self, cart: &Cart) -> Result<(), ParserError> {
+        // The bext_string_field helpers handle ASCII encoding +
+        // NUL-padding to a fixed length; cart's many fixed-length
+        // ASCII slots reuse them despite the bext-prefixed name.
+        self.write_bext_string_field(&cart.version, 4)?;
+        self.write_bext_string_field(&cart.title, 64)?;
+        self.write_bext_string_field(&cart.artist, 64)?;
+        self.write_bext_string_field(&cart.cut_id, 64)?;
+        self.write_bext_string_field(&cart.client_id, 64)?;
+        self.write_bext_string_field(&cart.category, 64)?;
+        self.write_bext_string_field(&cart.classification, 64)?;
+        self.write_bext_string_field(&cart.out_cue, 64)?;
+        self.write_bext_string_field(&cart.start_date, 10)?;
+        self.write_bext_string_field(&cart.start_time, 8)?;
+        self.write_bext_string_field(&cart.end_date, 10)?;
+        self.write_bext_string_field(&cart.end_time, 8)?;
+        self.write_bext_string_field(&cart.producer_app_id, 64)?;
+        self.write_bext_string_field(&cart.producer_app_version, 64)?;
+        self.write_bext_string_field(&cart.user_def, 64)?;
+        // Signed per AES46-2002 §5.2.16.
+        self.write_i32::<LittleEndian>(cart.level_reference)?;
+        for timer in &cart.post_timers {
+            self.write_fourcc(timer.usage)?;
+            self.write_u32::<LittleEndian>(timer.value)?;
+        }
+        self.write_all(&cart.reserved)?;
+        // URL field is absent in legacy version "0000".
+        if !cart.is_legacy_v0() {
+            self.write_bext_string_field(&cart.url, 1024)?;
+        }
+        // tag_text is variable-length, no NUL pad. RIFF odd-length
+        // pad byte is added by the WaveChunkWriter wrapper, not here.
+        let coding = ASCII
+            .encode(&cart.tag_text, EncoderTrap::Ignore)
+            .expect("Error encoding tag_text");
         self.write_all(&coding)?;
         Ok(())
     }
@@ -213,6 +256,81 @@ where
                     .decode(&buf, DecoderTrap::Ignore)
                     .expect("Error decoding text")
             },
+        })
+    }
+
+    fn read_cart(&mut self, chunk_size: u64) -> Result<Cart, ParserError> {
+        let version = self.read_bext_string_field(4)?;
+        let title = self.read_bext_string_field(64)?;
+        let artist = self.read_bext_string_field(64)?;
+        let cut_id = self.read_bext_string_field(64)?;
+        let client_id = self.read_bext_string_field(64)?;
+        let category = self.read_bext_string_field(64)?;
+        let classification = self.read_bext_string_field(64)?;
+        let out_cue = self.read_bext_string_field(64)?;
+        let start_date = self.read_bext_string_field(10)?;
+        let start_time = self.read_bext_string_field(8)?;
+        let end_date = self.read_bext_string_field(10)?;
+        let end_time = self.read_bext_string_field(8)?;
+        let producer_app_id = self.read_bext_string_field(64)?;
+        let producer_app_version = self.read_bext_string_field(64)?;
+        let user_def = self.read_bext_string_field(64)?;
+        // Signed per AES46-2002 §5.2.16.
+        let level_reference = self.read_i32::<LittleEndian>()?;
+        let mut post_timers: [CartTimer; 8] = <[CartTimer; 8]>::default();
+        for timer in &mut post_timers {
+            let usage_bytes: [u8; 4] = {
+                let mut buf = [0u8; 4];
+                self.read_exact(&mut buf)?;
+                buf
+            };
+            timer.usage = FourCC::from(usage_bytes);
+            timer.value = self.read_u32::<LittleEndian>()?;
+        }
+        let reserved: [u8; 276] = {
+            let mut buf = [0u8; 276];
+            self.read_exact(&mut buf)?;
+            buf
+        };
+        // Legacy "0000" cart chunks omit the 1024-byte URL field.
+        let is_legacy = version == "0000";
+        let url = if is_legacy {
+            String::new()
+        } else {
+            self.read_bext_string_field(1024)?
+        };
+        let fixed_size: u64 = if is_legacy { 1024 } else { 2048 };
+        let tag_text_len = chunk_size.saturating_sub(fixed_size);
+        let tag_text = if tag_text_len > 0 {
+            let mut tag_buf = vec![0u8; tag_text_len as usize];
+            self.read_exact(&mut tag_buf)?;
+            ASCII
+                .decode(&tag_buf, DecoderTrap::Ignore)
+                .expect("Error decoding tag_text")
+        } else {
+            String::new()
+        };
+        Ok(Cart {
+            version,
+            title,
+            artist,
+            cut_id,
+            client_id,
+            category,
+            classification,
+            out_cue,
+            start_date,
+            start_time,
+            end_date,
+            end_time,
+            producer_app_id,
+            producer_app_version,
+            user_def,
+            level_reference,
+            post_timers,
+            reserved,
+            url,
+            tag_text,
         })
     }
 }

--- a/src/fourcc.rs
+++ b/src/fourcc.rs
@@ -5,7 +5,7 @@ use std::io;
 ///
 /// For idetifying chunks, structured contiguous slices or segments
 /// within a WAV file.
-#[derive(Eq, PartialEq, Hash, Copy, Clone)]
+#[derive(Default, Eq, PartialEq, Hash, Copy, Clone)]
 pub struct FourCC([u8; 4]);
 
 impl FourCC {
@@ -121,6 +121,7 @@ pub const FMT__SIG: FourCC = FourCC::make(b"fmt ");
 
 pub const BEXT_SIG: FourCC = FourCC::make(b"bext");
 //pub const FACT_SIG: FourCC = FourCC::make(b"fact");
+pub const CART_SIG: FourCC = FourCC::make(b"cart");
 pub const IXML_SIG: FourCC = FourCC::make(b"iXML");
 pub const AXML_SIG: FourCC = FourCC::make(b"axml");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod list_form;
 mod parser;
 
 mod bext;
+mod cart;
 mod chunks;
 mod cue;
 mod fmt;
@@ -44,6 +45,7 @@ mod wavereader;
 mod wavewriter;
 
 pub use bext::Bext;
+pub use cart::{Cart, CartTimer};
 pub use common_format::{
     CommonFormat, WAVE_TAG_EXTENDED, WAVE_TAG_FLOAT, WAVE_TAG_MPEG, WAVE_TAG_PCM,
     WAVE_UUID_BFORMAT_FLOAT, WAVE_UUID_BFORMAT_PCM, WAVE_UUID_FLOAT, WAVE_UUID_MPEG, WAVE_UUID_PCM,
@@ -53,6 +55,7 @@ pub use errors::Error;
 pub use fmt::{
     ADMAudioID, ChannelDescriptor, ChannelMask, ReadWavAudioData, WaveFmt, WaveFmtExtended,
 };
+pub use fourcc::FourCC;
 pub use sample::{Sample, I24};
 pub use wavereader::{AudioFrameReader, WaveReader};
 pub use wavewriter::{AudioFrameWriter, WaveWriter};

--- a/src/wavereader.rs
+++ b/src/wavereader.rs
@@ -8,14 +8,15 @@ use std::io::SeekFrom::Start;
 use std::io::{BufReader, Read, Seek};
 
 use super::bext::Bext;
+use super::cart::Cart;
 use super::chunks::ReadBWaveChunks;
 use super::cue::Cue;
 use super::errors::Error as ParserError;
 use super::errors::Error;
 use super::fmt::{ChannelDescriptor, ChannelMask, WaveFmt};
 use super::fourcc::{
-    FourCC, ReadFourCC, ADTL_SIG, AXML_SIG, BEXT_SIG, CUE__SIG, DATA_SIG, FLLR_SIG, FMT__SIG,
-    IXML_SIG, JUNK_SIG, LIST_SIG,
+    FourCC, ReadFourCC, ADTL_SIG, AXML_SIG, BEXT_SIG, CART_SIG, CUE__SIG, DATA_SIG, FLLR_SIG,
+    FMT__SIG, IXML_SIG, JUNK_SIG, LIST_SIG,
 };
 use super::parser::Parser;
 use super::{CommonFormat, Sample, I24};
@@ -312,6 +313,23 @@ impl<R: Read + Seek> WaveReader<R> {
         if result > 0 {
             let mut bext_cursor = Cursor::new(bext_buff);
             Ok(Some(bext_cursor.read_bext()?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// The AES46-2002 `cart` chunk for this file, if present.
+    ///
+    /// Carries broadcast-automation cart metadata: title, artist,
+    /// scheduling timestamps, level reference, post-roll timers, and
+    /// a free-form tag-text trailer.
+    pub fn cart(&mut self) -> Result<Option<Cart>, ParserError> {
+        let mut buf: Vec<u8> = vec![];
+        let result = self.read_chunk(CART_SIG, 0, &mut buf)?;
+        if result > 0 {
+            let chunk_size = buf.len() as u64;
+            let mut cursor = Cursor::new(buf);
+            Ok(Some(cursor.read_cart(chunk_size)?))
         } else {
             Ok(None)
         }

--- a/src/wavewriter.rs
+++ b/src/wavewriter.rs
@@ -6,12 +6,13 @@ use crate::CommonFormat;
 
 use super::fmt::WaveFmt;
 use super::fourcc::{
-    FourCC, WriteFourCC, AXML_SIG, BEXT_SIG, DATA_SIG, DS64_SIG, ELM1_SIG, FMT__SIG, IXML_SIG,
-    JUNK_SIG, RF64_SIG, RIFF_SIG, WAVE_SIG,
+    FourCC, WriteFourCC, AXML_SIG, BEXT_SIG, CART_SIG, DATA_SIG, DS64_SIG, ELM1_SIG, FMT__SIG,
+    IXML_SIG, JUNK_SIG, RF64_SIG, RIFF_SIG, WAVE_SIG,
 };
 use super::{Error, Sample, I24};
 //use super::common_format::CommonFormat;
 use super::bext::Bext;
+use super::cart::Cart;
 use super::chunks::WriteBWaveChunks;
 
 use byteorder::LittleEndian;
@@ -359,6 +360,15 @@ where
         c.write_bext(bext)?;
         let buf = c.into_inner();
         self.write_chunk(BEXT_SIG, &buf)?;
+        Ok(())
+    }
+
+    /// Write an AES46-2002 `cart` chunk to the file.
+    pub fn write_cart(&mut self, cart: &Cart) -> Result<(), Error> {
+        let mut c = Cursor::new(vec![0u8; 0]);
+        c.write_cart(cart)?;
+        let buf = c.into_inner();
+        self.write_chunk(CART_SIG, &buf)?;
         Ok(())
     }
 


### PR DESCRIPTION
Adds support for the [AES46-2002](http://www.cartchunk.org/) `cart` chunk used by broadcast automation systems for cart label metadata: title/artist/category, scheduling timestamps, level reference, post-roll timer marks, and a free-form tag-text trailer.

This is codec-independent and shows up in plenty of broadcast WAVs regardless of audio format, which is why it's a separate PR from the MPEG-related additions.

Continuing the broadcast-WAV work for PRX (Public Radio Exchange) — thanks again for `bwavfile`. The chunk-trait pattern made `cart` straightforward to add even though it's the largest single chunk type in the codebase (2048 fixed bytes plus variable tag_text).

## Layout

The chunk has a fixed 2048-byte base for `Version >= "0101"` plus a variable-length `tag_text` trailer. The legacy `"0000"` version omits the 1024-byte URL field (1024-byte base instead of 2048); both are handled.

A couple of spec details worth flagging because they could otherwise be guessed wrong:

- `level_reference` is `i32` per AES46-2002 §5.2.16 ("signed 32-bit integer"). Real-world files tend to use positive values so the signedness rarely matters in practice, but the spec is unambiguous.
- The 276 reserved bytes are `[u8; 276]`, not a string. The spec deliberately permits arbitrary bytes there so vendors can store proprietary extensions, so the reserved region is preserved as raw bytes for byte-exact round-trip.

## Changes

- `src/cart.rs` (new): `Cart` and `CartTimer` structs, `Default` impl, `is_legacy_v0` and `fixed_size` helpers, unit tests
- `src/fourcc.rs`: add `CART_SIG`, plus `#[derive(Default)]` on `FourCC` so `CartTimer::default()` produces an "unused" timer with a zero `usage` FourCC per AES46-2002
- `src/chunks.rs`: add `read_cart` / `write_cart` to the existing `ReadBWaveChunks` / `WriteBWaveChunks` traits; cart's many fixed-length ASCII slots reuse the existing `bext_string_field` helpers
- `src/wavereader.rs`: `WaveReader::cart() -> Result<Option<Cart>>`. The reader passes `chunk_size` to `read_cart` so it can compute `tag_text` length and detect the legacy v0000 layout from the first 4 bytes
- `src/wavewriter.rs`: `WaveWriter::write_cart()`
- `src/lib.rs`: re-export `Cart`, `CartTimer`, `FourCC`

## Tests

- Round-trip of the default `Cart`
- Fully-populated `Cart` with all 8 post-timers and max-length strings
- Signed `level_reference` at `i32::MIN`, -1, 0, 1, `i32::MAX`
- Reserved 276 bytes filled with a non-ASCII pattern (verifies byte-exact preservation)
- `tag_text` empty / odd-length / long
- Legacy v0000 layout (no URL field, 1024-byte base)

## Test plan
- [x] All upstream tests continue to pass (`cargo test --lib --tests`)
- [x] 8 new cart-specific tests pass
- [x] `cargo fmt --check` clean