### PR TITLE
Fix clippy warnings across lib, tests, and examples

### DIFF
--- a/examples/blits.rs
+++ b/examples/blits.rs
@@ -35,7 +35,7 @@ fn dbfs_to_f32(dbfs: f32) -> f32 {
 }
 
 fn dbfs_to_signed_int(dbfs: f32, bit_depth: u16) -> i32 {
-    let full_code: i32 = (1i32 << bit_depth - 1) - 1;
+    let full_code: i32 = (1i32 << (bit_depth - 1)) - 1;
     ((full_code as f32) * dbfs_to_f32(dbfs)) as i32
 }
 
@@ -65,7 +65,7 @@ trait ToneBurstSignal {
 impl ToneBurstSignal for Vec<ToneBurst> {
     fn duration(&self, sample_rate: u32) -> u64 {
         self.iter()
-            .fold(0u64, |accum, &item| accum + &item.duration(sample_rate))
+            .fold(0u64, |accum, &item| accum + item.duration(sample_rate))
     }
 
     fn signal(&self, t: u64, sample_rate: u32, bit_depth: u16) -> i32 {
@@ -73,7 +73,7 @@ impl ToneBurstSignal for Vec<ToneBurst> {
             .scan(0u64, |accum, &item| {
                 let dur = item.duration(sample_rate);
                 let this_time_range = *accum..(*accum + dur);
-                *accum = *accum + dur;
+                *accum += dur;
                 Some((this_time_range, item))
             })
             .find(|(range, _)| range.contains(&t))
@@ -255,7 +255,7 @@ fn main() -> io::Result<()> {
 
     let filename = matches.value_of("OUTPUT").unwrap();
 
-    match create_blits_file(&filename, sample_rate, bits_per_sample) {
+    match create_blits_file(filename, sample_rate, bits_per_sample) {
         Err(Error::IOError(x)) => panic!("IO Error: {:?}", x),
         Err(err) => panic!("Error: {:?}", err),
         Ok(()) => Ok(()),

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -8,8 +8,6 @@ use byteorder::LittleEndian;
 use byteorder::ReadBytesExt;
 
 // Need more test cases for ADMAudioID
-#[allow(dead_code)]
-
 /// ADM Audio ID record.
 ///
 /// This structure relates a channel in the wave file to either a common ADM
@@ -21,6 +19,7 @@ use byteorder::ReadBytesExt;
 ///
 /// See BS.2088-1 § 8, also BS.2094, also blahblahblah...
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct ADMAudioID {
     pub track_uid: [char; 12],
     pub channel_format_ref: [char; 14],
@@ -154,7 +153,7 @@ pub struct WaveFmtExtended {
 /// - [Sampler Metadata](http://www.piclist.com/techref/io/serial/midi/wave.html)
 /// - [Audio File Format Specifications](http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html) (September 2022) Prof. Peter Kabal, MMSP Lab, ECE, McGill University
 /// - [Multimedia Programming Interface and Data Specifications 1.0](http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/Docs/riffmci.pdf)
-///    (August 1991), IBM Corporation and Microsoft Corporation
+///   (August 1991), IBM Corporation and Microsoft Corporation
 ///
 /// [rfc3261]: https://tools.ietf.org/html/rfc2361
 
@@ -429,6 +428,7 @@ where
     }
 }
 
+#[allow(dead_code)]
 trait WriteWavAudioData {
     fn write_i32_frames(&mut self, format: WaveFmt, from: &[i32]) -> Result<usize, std::io::Error>;
     fn write_f32_frames(&mut self, format: WaveFmt, from: &[f32]) -> Result<usize, std::io::Error>;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,6 +18,7 @@ use super::fourcc::{BW64_SIG, DATA_SIG, DS64_SIG, RF64_SIG, RIFF_SIG, WAVE_SIG};
 const RF64_SIZE_MARKER: u32 = 0xFF_FF_FF_FF;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum Event {
     StartParse,
     ReadHeader {

--- a/src/wavereader.rs
+++ b/src/wavereader.rs
@@ -245,7 +245,7 @@ impl<R: Read + Seek> WaveReader<R> {
     /// will return an `Err(errors::Error)` immediately if there is a structural
     /// inconsistency that makes the stream unreadable or if it's missing
     /// essential components that make interpreting the audio data impossible.
-
+    ///
     /// ```rust
     /// use std::fs::File;
     /// use std::io::{Error,ErrorKind};

--- a/src/wavewriter.rs
+++ b/src/wavewriter.rs
@@ -505,7 +505,7 @@ fn test_write_audio() {
     let data_size = cursor.read_u32::<LittleEndian>().unwrap(); //4
     assert_eq!(data_size, 9);
 
-    let tell = cursor.seek(SeekFrom::Current(0)).unwrap();
+    let tell = cursor.stream_position().unwrap();
     assert!(tell % 0x4000 == 0);
 
     assert_eq!(
@@ -560,7 +560,7 @@ fn test_create_rf64() {
     let format = WaveFmt::new_pcm_stereo(48000, 24);
     let w = WaveWriter::new(&mut cursor, format).unwrap();
 
-    let buflen = 16000 as u64;
+    let buflen = 16000_u64;
 
     let buf = vec![0i32; buflen as usize];
 

--- a/tests/ffprobe_media_tests.rs
+++ b/tests/ffprobe_media_tests.rs
@@ -20,7 +20,7 @@ where
     let mut json_file = File::open("tests/ffprobe_media_tests.json").unwrap();
     let mut s = String::new();
     json_file.read_to_string(&mut s).unwrap();
-    if let Value::Array(v) = from_str(&mut s).unwrap() {
+    if let Value::Array(v) = from_str(&s).unwrap() {
         /* */
         v.iter()
             .filter(|value| !value["format"]["filename"].is_null())

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -12,7 +12,7 @@ fn test_open() {
     match WaveReader::open(path) {
         Ok(_) => (),
         Err(x) => {
-            assert!(false, "Opened error.wav with unexpected error {:?}", x)
+            panic!("Opened error.wav with unexpected error {:?}", x)
         }
     }
 }
@@ -27,7 +27,7 @@ fn test_format_silence() -> Result<(), Error> {
 
     assert_eq!(format.sample_rate, 44100);
     assert_eq!(format.channel_count, 1);
-    assert_eq!(format.tag as u16, 1);
+    assert_eq!({ format.tag }, 1);
     Ok(())
 }
 
@@ -35,11 +35,7 @@ fn test_format_silence() -> Result<(), Error> {
 fn test_format_error() {
     let path = "tests/media/error.wav";
 
-    if let Ok(_) = WaveReader::open(path) {
-        assert!(false);
-    } else {
-        assert!(true);
-    }
+    assert!(WaveReader::open(path).is_err());
 }
 
 #[test]
@@ -59,21 +55,19 @@ fn test_minimal_wave() {
 
     let mut w = WaveReader::open(path).expect("Failure opening file");
 
-    if let Err(Error::NotMinimalWaveFile) = w.validate_minimal() {
-        assert!(true);
-    } else {
-        assert!(false);
-    }
+    assert!(matches!(
+        w.validate_minimal(),
+        Err(Error::NotMinimalWaveFile)
+    ));
 
     let min_path = "tests/media/ff_minimal.wav";
 
     let mut w = WaveReader::open(min_path).expect("Failure opening file");
 
-    if let Err(Error::NotMinimalWaveFile) = w.validate_minimal() {
-        assert!(false);
-    } else {
-        assert!(true);
-    }
+    assert!(!matches!(
+        w.validate_minimal(),
+        Err(Error::NotMinimalWaveFile)
+    ));
 }
 
 #[test]
@@ -164,7 +158,7 @@ fn test_frame_reader_consumes_reader() {
     fn from_wav_filename(
         wav_filename: &str,
     ) -> Result<(WaveFmt, AudioFrameReader<std::io::BufReader<File>>), ()> {
-        if let Ok(mut r) = WaveReader::open(&wav_filename) {
+        if let Ok(mut r) = WaveReader::open(wav_filename) {
             let format = r.format().unwrap();
             let frame_reader = r.audio_frame_reader().unwrap();
             Ok((format, frame_reader))


### PR DESCRIPTION
Hi! A small cleanup PR — independent of the MPEG/cart/fact-mext work in #23/#24/#25/#26 and could land anytime.

This resolves all warnings reported by `cargo clippy --lib --tests --examples` on stable. No behavior changes, no public API changes, no test-coverage changes. Each fix is the literal clippy-suggested rewrite where one was offered.

## Summary

**Library (`src/`):**
- `fmt.rs` — move a misplaced `#[allow(dead_code)]` (which had a blank line between the attribute and its target, so it didn't actually apply) onto the `ADMAudioID` struct itself; mark the dead-stub `WriteWavAudioData` trait with `#[allow(dead_code)]` alongside its existing `todo!()` bodies; fix a doc-list overindentation (3→2 spaces).
- `wavereader.rs` — replace the empty line between a doc comment and its fenced rustdoc example with `///` so the example stays attached.
- `wavewriter.rs` — `cursor.seek(SeekFrom::Current(0))` → `cursor.stream_position()`; `16000 as u64` → `16000_u64`.
- `parser.rs` — `#[allow(dead_code)]` on the public `Event` enum. The `signature`/`length_field`/`file_size`/`long_sizes` fields are populated for `Debug` output but never read by name, so dead-code analysis doesn't see them; the allow keeps Debug-derived enums working without forcing field renames.

**Tests:**
- `integration_test.rs` — `assert!(false, ...)` → `panic!(...)`; `assert!(false)`/`assert!(true)` pairs collapsed to `assert!(...)` / `assert!(matches!(...))`; `format.tag as u16` → `{ format.tag }` (silences the same-type-cast warning while also avoiding a packed-field reference); `if let Ok(_) = ...` → `.is_ok()` / `.is_err()`; drop a needless `&` on an `AsRef<Path>` argument.
- `ffprobe_media_tests.rs` — `from_str(&mut s)` → `from_str(&s)` (`serde_json::from_str` takes `&str`).

**Examples:**
- `blits.rs` — parenthesize `1i32 << (bit_depth - 1)`; drop a needless `&` in `accum + &item.duration(...)`; `*accum = *accum + dur` → `*accum += dur`; drop a redundant borrow on a `String` argument.

Verified locally with `cargo clippy --lib --tests --examples` (clean) and `cargo test --lib --tests` (22 tests pass).

Thanks again for all the upstream work — happy to split this into per-area commits if you'd prefer.